### PR TITLE
Refactor Background into separate component, change window scroll hook, fixes 79

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -890,13 +890,6 @@
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
-    "@rehooks/window-scroll-position": {
-      "version": "github:rehooks/window-scroll-position#0d935b8cbc8c215c6d832d31bc3150896e4e50d9",
-      "from": "github:rehooks/window-scroll-position",
-      "requires": {
-        "lodash.throttle": "^4.1.1"
-      }
-    },
     "@svgr/babel-plugin-add-jsx-attribute": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@rehooks/window-scroll-position": "github:rehooks/window-scroll-position",
     "bootstrap": "^4.2.1",
     "google-map-react": "^1.1.2",
     "node-sass": "^4.11.0",

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import useWindowScrollPosition from '@rehooks/window-scroll-position';
 
 import About from './About/About';
 import Location from './Location/Location';
@@ -11,33 +10,24 @@ import FAQ from './Faq/Faq';
 import Speakers from './Speakers/Speakers';
 import Sponsors from './Sponsors/Sponsors';
 import Jobs from './Jobs/Jobs';
+import Background from './Background/Background';
 
 import './App.scss';
 
-const App = () => {
-  const position = useWindowScrollPosition({
-    throttle: 0,
-  });
-  const backgroundOffset = 0.4 * position.y;
-
-  return (
-    <div className="App">
-      <Header />
-      <Intro />
-      <About />
-      <Speakers />
-      <Sponsors />
-      <Team />
-      <Location />
-      <Jobs />
-      <FAQ />
-      <Footer />
-      <div
-        className="BackgroundIllustration"
-        style={{ backgroundPositionY: `${backgroundOffset}px` }}
-      />
-    </div>
-  );
-};
+const App = () => (
+  <div className="App">
+    <Header />
+    <Intro />
+    <About />
+    <Speakers />
+    <Sponsors />
+    <Team />
+    <Location />
+    <Jobs />
+    <FAQ />
+    <Footer />
+    <Background />
+  </div>
+);
 
 export default App;

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,5 +1,6 @@
 .App {
   position: relative;
+  overflow: hidden;
 
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
@@ -8,21 +9,6 @@
 
   .App-link {
     color: #61dafb;
-  }
-
-  .BackgroundIllustration {
-    // background: red;
-    position: absolute;
-    top: 100vh;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: -1;
-    background-image: url('/background-pattern.png');
-    background-position-x: center;
-    background-size: 95%;
-    background-repeat: repeat-y;
-    opacity: .7;
   }
 }
 

--- a/src/Background/Background.js
+++ b/src/Background/Background.js
@@ -1,0 +1,49 @@
+import * as React from 'react';
+
+import './Background.scss';
+
+function useTranslateOnScroll(ref, ratio = 1) {
+  const frame = React.useRef(0);
+
+  const setStyle = (y) => {
+    if (ref.current) {
+      // we are bypassing React as the direct DOM changes are faster,
+      // wheres React state updates cause FPS drop
+      ref.current.style.transform = `translateY(${ratio * y}px)`; // eslint-disable-line no-param-reassign
+    }
+  };
+
+  React.useEffect(() => {
+    const handler = () => {
+      cancelAnimationFrame(frame.current);
+
+      frame.current = requestAnimationFrame(() => {
+        setStyle(window.scrollY);
+      });
+    };
+
+    window.addEventListener('scroll', handler, {
+      capture: false,
+      passive: true,
+    });
+
+    return () => {
+      cancelAnimationFrame(frame.current);
+      window.removeEventListener('scroll', handler);
+    };
+  }, []);
+}
+
+const Background = () => {
+  const ref = React.useRef(null);
+  useTranslateOnScroll(ref, 0.4);
+
+  return (
+    <div
+      ref={ref}
+      className="BackgroundIllustration"
+    />
+  );
+};
+
+export default Background;

--- a/src/Background/Background.scss
+++ b/src/Background/Background.scss
@@ -1,0 +1,16 @@
+.BackgroundIllustration {
+  // background: red;
+  position: absolute;
+  top: 100vh;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: -1;
+  background-image: url('/background-pattern.png');
+  background-position-x: center;
+  background-size: 95%;
+  background-repeat: repeat-y;
+  opacity: .7;
+
+  transform: translateY(0);
+}


### PR DESCRIPTION
* Refactor Background into a separate component to avoid re-rendering the whole app on scroll event
* Change `useWindowScroll` hook to `react-use` as it uses `requestAnimationFrame` which make animation on scroll event more smoother
* Change usage of `background-position-y` to `transform: translateY()` to use the browsers hardware acceleration 

